### PR TITLE
allow header avatar configuration

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -13,3 +13,23 @@ bugs: https://github.com/getgrav/grav-theme-lingonberry/issues
 license: GPL
 dependencies:
   - { name: grav, version: '>=1.5.10' }
+
+form:
+  fields:
+    use_gravatar:
+        type: toggle
+        label: Gravatar Image in Blog header
+        highlight: 1
+        default: 1
+        options:
+          1: PLUGIN_ADMIN.ENABLED
+          0: PLUGIN_ADMIN.DISABLED
+        validate:
+          type: bool
+
+    blog_avatar:
+      type: file
+      label: Blog Avatar image
+      destination: 'user/themes/lingonberry/assets'
+      accept:
+        - image/*

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -1,7 +1,11 @@
 <div class="header section">
   <div class="header-inner section-inner">
     <a href="{% if site.author.url %}{{ site.author.url }}{% else %}{{ base_url_absolute }}{% endif %}" title="{{ site.title }}" rel="home" class="logo">
+    {% if grav.theme.config.use_gravatar %}
       <img src="https://www.gravatar.com/avatar/{{ site.author.gravatar|md5 }}?s=90" alt="Gravatar"/>
+    {% elseif grav.theme.config.blog_avatar %}
+         {{ media['user://themes/lingonberry/assets/' ~ grav.theme.config.blog_avatar|first.name].cropZoom(90,90).html() }} #}
+    {% endif %}
     </a>
 
     {% if site.title  %}


### PR DESCRIPTION
Adds an option to the template configuration to choose another avatar image than the author's Gravatar:

![grafik](https://user-images.githubusercontent.com/510681/61190789-1a707080-a6a2-11e9-857b-680fc00e939b.png)
